### PR TITLE
Replaced usage of .dev tld with (more appropriate) .test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 - Update your `/etc/hosts` file
 
     ```
-    echo 192.168.59.76   testbox.dev www.testbox.dev | sudo tee -a /etc/hosts
+    echo 192.168.59.76   testbox.test www.testbox.test | sudo tee -a /etc/hosts
     ```
 
 - Next you can simply use the `vagrant up` command to start provisioning your local environment!
-- Adding an index.php file into your repository should allow you to see its contents at http://www.testbox.dev
+- Adding an index.php file into your repository should allow you to see its contents at http://www.testbox.test
 - Remember part of the process is to see how you work so commit and push changes as you would on day to day projects.
 
 | Type           | Value                  |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 Vagrant.require_version ">= 1.8.6"
 
 VAGRANT_API_VERSION = "2"
-GUEST_HOSTNAME = "testbox.dev"
+GUEST_HOSTNAME = "testbox.test"
 GUEST_NETWORK_IP = "192.168.59.76"
 GUEST_MEMORY_LIMIT = "1024"
 GUEST_CPU_LIMIT = "1"


### PR DESCRIPTION
Since chrome 63/ff 59 forced HSTS on .dev, the current vagrantfile is
unusable (unless nginx playbook is adjusted accordingly to serve https
and host adjusted to add that certificate to trusted list).
.test, on the other hand, is a standard, reserved for development
purposes tld (see https://tools.ietf.org/html/rfc6761 #6.2)