### PR TITLE
Update PHP from 7.3 to 7.4

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -2,4 +2,4 @@ site_root_folder: /vagrant
 nginx_port: 80
 site_index: index.php
 timezone: America/New_York
-php_version: 7.3
+php_version: 7.4


### PR DESCRIPTION
When I was working on reviewing projects for the growth engineer, I was having issues running this box from a fresh install. Specifically, the following error was presented:
```
*************
    default: changed: [127.0.0.1]
    default:
    default: TASK [php : Set custom links for cli] ******************************************
    default: fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Error while linking: [Errno 2] No such file or directory", "path": "/etc/php/7.3/cli/conf.d/30-custom.ini", "state": "absent"}
```

At least one candidate has noticed this issue and has reached out to Dave about this issue. 

Digging into the issue, I noticed that the `cli/` and `fpm/` folders are no longer being installed under `/etc/php/7.3/` but instead under `/etc/php/7.4`. 

This PR updates the variable to properly reference the correct folder while doing the Vagrant tasks.
